### PR TITLE
update wordpress plugin url address

### DIFF
--- a/sources/api/errno.md
+++ b/sources/api/errno.md
@@ -161,6 +161,7 @@ API 请求失败时，服务端会返回一个 JSON 格式的响应体。它可�
 | 403 			| 40300028 			| request has expired |
 | 403 			| 40300029 			| purge too much items |
 | 403 			| 40300030 			| wrong content-length header |
+| 403           | 40310007          | Binded domain and source domain can't be the same|
 | 404 			| 40400001 			| file or directory not found    |
 | 404 			| 40400002 			| base64 decoded err    |
 | 406 			| 40600001 			| dir not acceptable    |

--- a/sources/download/index.md
+++ b/sources/download/index.md
@@ -308,7 +308,7 @@
 	<li>
         <strong>WordPress</strong>
         <div class="links">
-            <a href="https://github.com/ihacklog/hacklog-remote-attachment-upyun" class="btn btn-xs" target="_blank"><i class="fa fa-github"></i>GitHub</a>
+            <a href="https://github.com/monkey-wenjun/hacklog-remote-attachment-upyun" class="btn btn-xs" target="_blank"><i class="fa fa-github"></i>GitHub</a>
         </div>
     </li>
 	<li>


### PR DESCRIPTION
原先 ihacklog 的 WP 插件下载地址 404 了(起因: [被 github 干了](http://80x86.io/post/got-fucked-by-github) ), 现在替换为另外一个插件地址。